### PR TITLE
chore: Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/benbria/eslint-config-benbria#readme",
   "peerDependencies": {
-    "eslint": "^6.7.1",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-promise": "^4.2.1"
+    "eslint": "^7.32.0",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-promise": "^5.0.0"
   }
 }


### PR DESCRIPTION
Build for `node-amqp-connection-manager` is failing with npm `8.1.4` due to mismatching versions of peerDependencies. This update fixes those issues.